### PR TITLE
feat(slate-plugin-separation-line): initial

### DIFF
--- a/packages/slate-plugin-separation-line/README.md
+++ b/packages/slate-plugin-separation-line/README.md
@@ -1,0 +1,1 @@
+# `@artibox/slate-plugin-separation-line`

--- a/packages/slate-plugin-separation-line/package.json
+++ b/packages/slate-plugin-separation-line/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@artibox/slate-plugin-separation-line",
+  "version": "0.0.0",
+  "description": "",
+  "author": "Rytass",
+  "homepage": "https://github.com/React-Artibox/artibox#readme",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "jsnext:main": "./esm/index.js",
+  "typings": "./esm/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/React-Artibox/artibox.git"
+  },
+  "bugs": {
+    "url": "https://github.com/React-Artibox/artibox/issues"
+  },
+  "scripts": {
+    "clean": "npm run build:clean",
+    "build:clean": "rm -rf ./{esm,lib} && rm -rf ./tsconfig.tsbuildinfo",
+    "build": "tsc && rollup --config rollup.config.js"
+  },
+  "dependencies": {
+    "@artibox/slate-core": "^0.0.0",
+    "@artibox/slate-renderer": "^0.0.0"
+  },
+  "peerDependencies": {
+    "react": "16.8.6"
+  },
+  "devDependencies": {
+    "react": "^16.11.0"
+  }
+}

--- a/packages/slate-plugin-separation-line/rollup.config.js
+++ b/packages/slate-plugin-separation-line/rollup.config.js
@@ -1,0 +1,15 @@
+import pkg from './package.json';
+import { getExternalFromPackages } from '../../tools/rollup/getExternalFromPackages';
+
+export default [
+  {
+    input: './esm/index.js',
+    output: [
+      {
+        file: './lib/index.js',
+        format: 'cjs'
+      }
+    ],
+    external: getExternalFromPackages(pkg)
+  }
+];

--- a/packages/slate-plugin-separation-line/src/index.ts
+++ b/packages/slate-plugin-separation-line/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  SEPARATION_LINE_TYPE,
+  SEPARATION_LINE_COMPONENT,
+  SEPARATION_LINE_COMMAND_ADD
+} from './separation-line.constants';
+export { SeparationLineCommandAdd, SeparationLineCommands } from './separation-line.commands';
+export { SeparationLinePluginConfig, SeparationLinePlugin } from './separation-line.plugin';
+export { useSeparationLineOnClick } from './separation-line.hooks';

--- a/packages/slate-plugin-separation-line/src/separation-line.commands.ts
+++ b/packages/slate-plugin-separation-line/src/separation-line.commands.ts
@@ -1,0 +1,20 @@
+import { Editor, Plugin } from 'slate';
+import { PARAGRAPH_TYPE } from '@artibox/slate-core';
+import { SEPARATION_LINE_COMMAND_ADD } from './separation-line.constants';
+
+export type SeparationLineCommandAdd = (editor: Editor) => Editor;
+
+export type SeparationLineCommands = Plugin['commands'] & {
+  [SEPARATION_LINE_COMMAND_ADD]: SeparationLineCommandAdd;
+};
+
+export function SeparationLineCommands(type: string): SeparationLineCommands {
+  return {
+    [SEPARATION_LINE_COMMAND_ADD]: editor =>
+      editor
+        .insertBlock(type)
+        .insertBlock(PARAGRAPH_TYPE)
+        .moveToStartOfBlock()
+        .focus()
+  };
+}

--- a/packages/slate-plugin-separation-line/src/separation-line.constants.ts
+++ b/packages/slate-plugin-separation-line/src/separation-line.constants.ts
@@ -1,0 +1,8 @@
+export const SEPARATION_LINE_TYPE = 'separation line';
+export type SEPARATION_LINE_TYPE = typeof SEPARATION_LINE_TYPE;
+
+export const SEPARATION_LINE_COMPONENT = 'hr';
+export type SEPARATION_LINE_COMPONENT = typeof SEPARATION_LINE_COMPONENT;
+
+export const SEPARATION_LINE_COMMAND_ADD = 'Command[Separation Line] Add';
+export type SEPARATION_LINE_COMMAND_ADD = typeof SEPARATION_LINE_COMMAND_ADD;

--- a/packages/slate-plugin-separation-line/src/separation-line.hooks.ts
+++ b/packages/slate-plugin-separation-line/src/separation-line.hooks.ts
@@ -1,0 +1,15 @@
+import { Editor } from 'slate';
+import { useMemo, MouseEventHandler } from 'react';
+import { getCommand } from '@artibox/slate-core';
+import { SEPARATION_LINE_COMMAND_ADD } from './separation-line.constants';
+import { SeparationLineCommandAdd } from './separation-line.commands';
+
+export function useSeparationLineOnClick(editor: Editor) {
+  return useMemo<MouseEventHandler>(() => {
+    const command = getCommand<SeparationLineCommandAdd>(editor, SEPARATION_LINE_COMMAND_ADD);
+    return event => {
+      event.preventDefault();
+      command();
+    };
+  }, [editor]);
+}

--- a/packages/slate-plugin-separation-line/src/separation-line.plugin.ts
+++ b/packages/slate-plugin-separation-line/src/separation-line.plugin.ts
@@ -1,0 +1,27 @@
+import { Plugin } from 'slate-react';
+import { Required } from 'utility-types';
+import { CommonBlockRenderer } from '@artibox/slate-renderer';
+import { SEPARATION_LINE_TYPE, SEPARATION_LINE_COMPONENT } from './separation-line.constants';
+import { SeparationLineCommands } from './separation-line.commands';
+import { SeparationLineSchema } from './separation-line.schema';
+
+export interface SeparationLinePluginConfig {
+  type?: string;
+}
+
+export interface SeparationLinePlugin extends Required<Plugin, 'renderBlock' | 'schema'> {
+  commands: SeparationLineCommands;
+}
+
+export function SeparationLinePlugin(config?: SeparationLinePluginConfig): SeparationLinePlugin {
+  const type = (config && config.type) || SEPARATION_LINE_TYPE;
+  const commands = SeparationLineCommands(type);
+  const renderer = CommonBlockRenderer({ type, component: SEPARATION_LINE_COMPONENT, isVoid: true });
+  const schema = SeparationLineSchema(type);
+
+  return {
+    commands,
+    renderBlock: renderer.renderBlock,
+    schema
+  };
+}

--- a/packages/slate-plugin-separation-line/src/separation-line.schema.ts
+++ b/packages/slate-plugin-separation-line/src/separation-line.schema.ts
@@ -1,0 +1,9 @@
+export function SeparationLineSchema(type: string) {
+  return {
+    blocks: {
+      [type]: {
+        isVoid: true
+      }
+    }
+  };
+}

--- a/packages/slate-plugin-separation-line/tsconfig.json
+++ b/packages/slate-plugin-separation-line/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./esm",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [
+    { "path": "../slate-core" },
+    { "path": "../slate-renderer" }
+  ],
+  "include": [
+		"./src"
+  ],
+  "exclude": [
+    "node_modules",
+    "./esm",
+    "./lib",
+    "./**/*.test.*"
+  ]
+}

--- a/packages/slate-renderer/src/blocks/common-block.renderer.tsx
+++ b/packages/slate-renderer/src/blocks/common-block.renderer.tsx
@@ -5,12 +5,13 @@ import { Required } from 'utility-types';
 export interface CommonBlockRendererConfig {
   type: string;
   component: keyof ReactHTML | ComponentType<RenderAttributes>;
+  isVoid?: boolean;
 }
 
 export type CommonBlockRenderer = Required<Plugin, 'renderBlock'>;
 
 export function CommonBlockRenderer(config: CommonBlockRendererConfig): CommonBlockRenderer {
-  const { type, component: Component } = config;
+  const { type, component: Component, isVoid = false } = config;
 
   return {
     renderBlock(props, _, next) {
@@ -20,7 +21,8 @@ export function CommonBlockRenderer(config: CommonBlockRendererConfig): CommonBl
         return next();
       }
 
-      return <Component {...attributes}>{children}</Component>;
+      //  eslint-disable-next-line react/no-children-prop
+      return <Component {...attributes} children={isVoid ? undefined : children} />;
     }
   };
 }

--- a/stories/rich-editor/plugins.tsx
+++ b/stories/rich-editor/plugins.tsx
@@ -11,6 +11,7 @@ import {
 } from '@artibox/slate-plugin-strikethrough';
 import { UnderlinePlugin, useUnderlineIsActive, useUnderlineOnClick } from '@artibox/slate-plugin-underline';
 import { HeadingPlugin, useHeadingIsActive, useHeadingOnClick } from '@artibox/slate-plugin-heading';
+import { SeparationLinePlugin, useSeparationLineOnClick } from '@artibox/slate-plugin-separation-line';
 
 interface EditorPassable {
   editor: Editor;
@@ -55,6 +56,10 @@ const Heading3Button = createToggleButton(
   editor => useHeadingOnClick(editor, 3),
   'heading 3'
 );
+const SeparationLineButton = ({ editor }: EditorPassable) => {
+  const onClick = useSeparationLineOnClick(editor);
+  return <button onClick={onClick}>separation line</button>;
+};
 
 export const plugins: Plugin[] = [
   BoldPlugin(),
@@ -64,6 +69,7 @@ export const plugins: Plugin[] = [
   HeadingPlugin({
     disabled: [4, 5, 6]
   }),
+  SeparationLinePlugin(),
   {
     renderEditor: (_, editor, next) => {
       return (
@@ -75,6 +81,7 @@ export const plugins: Plugin[] = [
           <Heading1Button editor={editor} />
           <Heading2Button editor={editor} />
           <Heading3Button editor={editor} />
+          <SeparationLineButton editor={editor} />
           {next()}
         </>
       );


### PR DESCRIPTION
As title.

Some UX bugs seem caused by `slate` itself.
Shown as follows:

Anchor can be moved on the separation line by arrow keys.
But even though anchor on it, it couldn't be editable, maybe the bug can be ignored.
Or we need to find some solutions to let the separation line move anchor while it is focused.