### PR TITLE
feat(slate-plugin-blockquote): initial

### DIFF
--- a/packages/slate-plugin-blockquote/README.md
+++ b/packages/slate-plugin-blockquote/README.md
@@ -1,0 +1,1 @@
+# `@artibox/slate-plugin-blockquote`

--- a/packages/slate-plugin-blockquote/package.json
+++ b/packages/slate-plugin-blockquote/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@artibox/slate-plugin-blockquote",
+  "version": "0.0.0",
+  "description": "",
+  "author": "Rytass",
+  "homepage": "https://github.com/React-Artibox/artibox#readme",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./esm/index.js",
+  "jsnext:main": "./esm/index.js",
+  "typings": "./esm/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/React-Artibox/artibox.git"
+  },
+  "bugs": {
+    "url": "https://github.com/React-Artibox/artibox/issues"
+  },
+  "scripts": {
+    "clean": "npm run build:clean",
+    "build:clean": "rm -rf ./{esm,lib} && rm -rf ./tsconfig.tsbuildinfo",
+    "build": "tsc && rollup --config rollup.config.js"
+  },
+  "dependencies": {
+    "@artibox/slate-core": "^0.0.0",
+    "@artibox/slate-renderer": "^0.0.0",
+    "is-hotkey": "^0.1.6",
+    "utility-types": "^3.9.0"
+  },
+  "peerDependencies": {
+    "react": "16.8.6"
+  },
+  "devDependencies": {
+    "@types/slate": "^0.47.3",
+    "@types/slate-react": "^0.22.6",
+    "react": "^16.11.0"
+  }
+}

--- a/packages/slate-plugin-blockquote/rollup.config.js
+++ b/packages/slate-plugin-blockquote/rollup.config.js
@@ -1,0 +1,15 @@
+import pkg from './package.json';
+import { getExternalFromPackages } from '../../tools/rollup/getExternalFromPackages';
+
+export default [
+  {
+    input: './esm/index.js',
+    output: [
+      {
+        file: './lib/index.js',
+        format: 'cjs'
+      }
+    ],
+    external: getExternalFromPackages(pkg)
+  }
+];

--- a/packages/slate-plugin-blockquote/src/blockquote.commands.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.commands.ts
@@ -1,0 +1,64 @@
+import { Editor, Plugin } from 'slate';
+import { PARAGRAPH_TYPE } from '@artibox/slate-core';
+import {
+  BLOCKQUOTE_COMMAND_SOFT_BREAK,
+  BLOCKQUOTE_COMMAND_WRAP,
+  BLOCKQUOTE_COMMAND_UNWRAP,
+  BLOCKQUOTE_COMMAND_TOGGLE
+} from './blockquote.constants';
+import { BlockquoteQueryHas } from './blockquote.queries';
+
+export interface BlockquoteCommandsConfig {
+  type: string;
+  queryHas: BlockquoteQueryHas;
+}
+
+/**
+ * To soft break the current block inside blockquote and add one paragraph block below.
+ */
+export type BlockquoteCommandSoftBreak = (editor: Editor) => Editor;
+
+/**
+ * To wrap the current block with blockquote block.
+ */
+export type BlockquoteCommandWrap = (editor: Editor) => Editor;
+
+/**
+ * To unwrap the current blockquote block if it is.
+ */
+export type BlockquoteCommandUnwrap = (editor: Editor) => Editor;
+
+/**
+ * To toggle the blockquote block.
+ */
+export type BlockquoteCommandToggle = (editor: Editor) => Editor;
+
+export type BlockquoteCommands = Plugin['commands'] & {
+  [BLOCKQUOTE_COMMAND_SOFT_BREAK]: BlockquoteCommandSoftBreak;
+  [BLOCKQUOTE_COMMAND_WRAP]: BlockquoteCommandWrap;
+  [BLOCKQUOTE_COMMAND_UNWRAP]: BlockquoteCommandUnwrap;
+  [BLOCKQUOTE_COMMAND_TOGGLE]: BlockquoteCommandToggle;
+};
+
+export function BlockquoteCommands(config: BlockquoteCommandsConfig): BlockquoteCommands {
+  const { type, queryHas } = config;
+  const commandSoftBreak: BlockquoteCommandSoftBreak = editor =>
+    editor
+      .splitBlock()
+      .setBlocks(PARAGRAPH_TYPE)
+      .focus();
+  const commandWrap: BlockquoteCommandWrap = editor => editor.wrapBlock(type).focus();
+  const commandUnwrap: BlockquoteCommandUnwrap = editor => editor.unwrapBlock(type).focus();
+  const commandToggle: BlockquoteCommandToggle = editor => {
+    const active = queryHas(editor);
+    const command = active ? commandUnwrap : commandWrap;
+    return command(editor).focus();
+  };
+
+  return {
+    [BLOCKQUOTE_COMMAND_SOFT_BREAK]: commandSoftBreak,
+    [BLOCKQUOTE_COMMAND_WRAP]: commandWrap,
+    [BLOCKQUOTE_COMMAND_UNWRAP]: commandUnwrap,
+    [BLOCKQUOTE_COMMAND_TOGGLE]: commandToggle
+  };
+}

--- a/packages/slate-plugin-blockquote/src/blockquote.constants.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.constants.ts
@@ -1,0 +1,22 @@
+export const BLOCKQUOTE_TYPE = 'blockquote' as const;
+export type BLOCKQUOTE_TYPE = typeof BLOCKQUOTE_TYPE;
+
+export const BLOCKQUOTE_HOTKEY = 'ctrl+opt+q' as const;
+export type BLOCKQUOTE_HOTKEY = typeof BLOCKQUOTE_HOTKEY;
+
+export const BLOCKQUOTE_COMPONENT = 'blockquote' as const;
+export type BLOCKQUOTE_COMPONENT = typeof BLOCKQUOTE_COMPONENT;
+
+export const BLOCKQUOTE_QUERY_CURRENT_BLOCK = 'Query[Blockquote] Current Block' as const;
+export type BLOCKQUOTE_QUERY_CURRENT_BLOCK = typeof BLOCKQUOTE_QUERY_CURRENT_BLOCK;
+export const BLOCKQUOTE_QUERY_HAS = 'Query[Blockquote] Has' as const;
+export type BLOCKQUOTE_QUERY_HAS = typeof BLOCKQUOTE_QUERY_HAS;
+
+export const BLOCKQUOTE_COMMAND_SOFT_BREAK = 'Command[Blockquote] Soft Break' as const;
+export type BLOCKQUOTE_COMMAND_SOFT_BREAK = typeof BLOCKQUOTE_COMMAND_SOFT_BREAK;
+export const BLOCKQUOTE_COMMAND_WRAP = 'Command[Blockquote] Wrap' as const;
+export type BLOCKQUOTE_COMMAND_WRAP = typeof BLOCKQUOTE_COMMAND_WRAP;
+export const BLOCKQUOTE_COMMAND_UNWRAP = 'Command[Blockquote] Unwrap' as const;
+export type BLOCKQUOTE_COMMAND_UNWRAP = typeof BLOCKQUOTE_COMMAND_UNWRAP;
+export const BLOCKQUOTE_COMMAND_TOGGLE = 'Command[Blockquote] Toggle' as const;
+export type BLOCKQUOTE_COMMAND_TOGGLE = typeof BLOCKQUOTE_COMMAND_TOGGLE;

--- a/packages/slate-plugin-blockquote/src/blockquote.handlers.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.handlers.ts
@@ -1,0 +1,86 @@
+import { Plugin } from 'slate-react';
+import { isHotkey } from 'is-hotkey';
+import { BlockquoteQueryCurrentBlock } from './blockquote.queries';
+import { BlockquoteCommandSoftBreak, BlockquoteCommandUnwrap, BlockquoteCommandToggle } from './blockquote.commands';
+
+export interface BlockquoteHandlersConfig {
+  hotkey: string;
+  queryCurrentBlock: BlockquoteQueryCurrentBlock;
+  commandSoftBreak: BlockquoteCommandSoftBreak;
+  commandUnwrap: BlockquoteCommandUnwrap;
+  commandToggle: BlockquoteCommandToggle;
+}
+
+export interface BlockquoteHandlers {
+  onKeyDown: NonNullable<Plugin['onKeyDown']>;
+}
+
+export function BlockquoteHandlers(config: BlockquoteHandlersConfig): BlockquoteHandlers {
+  const { hotkey, queryCurrentBlock, commandSoftBreak, commandUnwrap, commandToggle } = config;
+  const isSaveHotkey = isHotkey(hotkey);
+
+  /**
+   * The handler of soft break.
+   */
+  const onModEnter: NonNullable<Plugin['onKeyDown']> = (event, editor, next) => {
+    const blockquoteBlock = queryCurrentBlock(editor);
+
+    if (!blockquoteBlock) {
+      return next();
+    }
+
+    event.preventDefault();
+
+    return commandSoftBreak(editor);
+  };
+
+  /**
+   * If the focused block inside blockquote is w/o any texts, unwrap the focused block.
+   */
+  const onEnter: NonNullable<Plugin['onKeyDown']> = (event, editor, next) => {
+    const blockquoteBlock = queryCurrentBlock(editor);
+    const currentBlock = editor.value.startBlock;
+
+    if (!blockquoteBlock || currentBlock.text.length !== 0) {
+      return next();
+    }
+
+    event.preventDefault();
+
+    return commandUnwrap(editor);
+  };
+
+  /**
+   * If the focused block inside blockquote and the selection is not expanded, unwrap the focused block.
+   */
+  const onBackSpace: NonNullable<Plugin['onKeyDown']> = (event, editor, next) => {
+    const blockquoteBlock = queryCurrentBlock(editor);
+    const { isExpanded, start } = editor.value.selection;
+
+    if (!blockquoteBlock || isExpanded || start.offset !== 0) {
+      return next();
+    }
+
+    event.preventDefault();
+
+    return commandUnwrap(editor);
+  };
+
+  return {
+    onKeyDown: (event, editor, next) => {
+      if (event.key === 'Enter') {
+        if (event.metaKey) {
+          return onModEnter(event, editor, next);
+        }
+
+        return onEnter(event, editor, next);
+      } else if (event.key === 'Backspace') {
+        return onBackSpace(event, editor, next);
+      } else if (isSaveHotkey(event as any)) {
+        return commandToggle(editor);
+      }
+
+      return next();
+    }
+  };
+}

--- a/packages/slate-plugin-blockquote/src/blockquote.hooks.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.hooks.ts
@@ -1,0 +1,21 @@
+import { Editor } from 'slate';
+import { useMemo, MouseEventHandler } from 'react';
+import { getQuery, getCommand } from '@artibox/slate-core';
+import { BLOCKQUOTE_QUERY_HAS, BLOCKQUOTE_COMMAND_TOGGLE } from './blockquote.constants';
+import { BlockquoteQueryHas } from './blockquote.queries';
+import { BlockquoteCommandWrap } from './blockquote.commands';
+
+export function useBlockquoteIsActive(editor: Editor) {
+  const query = useMemo(() => getQuery<BlockquoteQueryHas>(editor, BLOCKQUOTE_QUERY_HAS), [editor]);
+  return query();
+}
+
+export function useBlockquoteOnClick(editor: Editor) {
+  return useMemo<MouseEventHandler>(() => {
+    const command = getCommand<BlockquoteCommandWrap>(editor, BLOCKQUOTE_COMMAND_TOGGLE);
+    return event => {
+      event.preventDefault();
+      command();
+    };
+  }, [editor]);
+}

--- a/packages/slate-plugin-blockquote/src/blockquote.plugin.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.plugin.ts
@@ -1,0 +1,48 @@
+import { Plugin } from 'slate-react';
+import { Required } from 'utility-types';
+import { CommonBlockRenderer } from '@artibox/slate-renderer';
+import {
+  BLOCKQUOTE_TYPE,
+  BLOCKQUOTE_HOTKEY,
+  BLOCKQUOTE_COMPONENT,
+  BLOCKQUOTE_QUERY_CURRENT_BLOCK,
+  BLOCKQUOTE_QUERY_HAS,
+  BLOCKQUOTE_COMMAND_SOFT_BREAK,
+  BLOCKQUOTE_COMMAND_UNWRAP,
+  BLOCKQUOTE_COMMAND_TOGGLE
+} from './blockquote.constants';
+import { BlockquoteQueries } from './blockquote.queries';
+import { BlockquoteHandlers } from './blockquote.handlers';
+import { BlockquoteCommands } from './blockquote.commands';
+
+export interface BlockquotePluginConfig {
+  type?: string;
+  hotkey?: string;
+}
+
+export interface BlockquotePlugin extends Required<Plugin, 'onKeyDown' | 'renderBlock'> {
+  queries: BlockquoteQueries;
+  commands: BlockquoteCommands;
+}
+
+export function BlockquotePlugin(config?: BlockquotePluginConfig): BlockquotePlugin {
+  const type = (config && config.type) || BLOCKQUOTE_TYPE;
+  const hotkey = (config && config.hotkey) || BLOCKQUOTE_HOTKEY;
+  const queries = BlockquoteQueries(type);
+  const commands = BlockquoteCommands({ type, queryHas: queries[BLOCKQUOTE_QUERY_HAS] });
+  const handlers = BlockquoteHandlers({
+    hotkey,
+    queryCurrentBlock: queries[BLOCKQUOTE_QUERY_CURRENT_BLOCK],
+    commandSoftBreak: commands[BLOCKQUOTE_COMMAND_SOFT_BREAK],
+    commandUnwrap: commands[BLOCKQUOTE_COMMAND_UNWRAP],
+    commandToggle: commands[BLOCKQUOTE_COMMAND_TOGGLE]
+  });
+  const renderer = CommonBlockRenderer({ type, component: BLOCKQUOTE_COMPONENT });
+
+  return {
+    queries,
+    commands,
+    onKeyDown: handlers.onKeyDown,
+    renderBlock: renderer.renderBlock
+  };
+}

--- a/packages/slate-plugin-blockquote/src/blockquote.queries.ts
+++ b/packages/slate-plugin-blockquote/src/blockquote.queries.ts
@@ -1,0 +1,38 @@
+import { Editor, Plugin, Block } from 'slate';
+import { BLOCKQUOTE_QUERY_CURRENT_BLOCK, BLOCKQUOTE_QUERY_HAS } from './blockquote.constants';
+
+/**
+ * If the current block is blockquote or wrapped by blockquote, return the blockquote, or null.
+ */
+export type BlockquoteQueryCurrentBlock = (editor: Editor) => Block | null;
+
+/**
+ * To query if the current block is blockquote.
+ */
+export type BlockquoteQueryHas = (editor: Editor) => boolean;
+
+export type BlockquoteQueries = Plugin['queries'] & {
+  [BLOCKQUOTE_QUERY_CURRENT_BLOCK]: BlockquoteQueryCurrentBlock;
+  [BLOCKQUOTE_QUERY_HAS]: BlockquoteQueryHas;
+};
+
+export function BlockquoteQueries(type: string): BlockquoteQueries {
+  const queryCurrentBlock: BlockquoteQueryCurrentBlock = editor => {
+    const currentBlock = editor.value.startBlock as Block | null;
+
+    if (!currentBlock) {
+      return null;
+    } else if (currentBlock.type === type) {
+      return currentBlock;
+    }
+
+    const parent = editor.value.document.getParent(currentBlock.key) as Block | null;
+    return parent && parent.type === type ? parent : null;
+  };
+  const queryHas: BlockquoteQueryHas = editor => !!queryCurrentBlock(editor);
+
+  return {
+    [BLOCKQUOTE_QUERY_CURRENT_BLOCK]: queryCurrentBlock,
+    [BLOCKQUOTE_QUERY_HAS]: queryHas
+  };
+}

--- a/packages/slate-plugin-blockquote/src/index.ts
+++ b/packages/slate-plugin-blockquote/src/index.ts
@@ -1,0 +1,22 @@
+export {
+  BLOCKQUOTE_TYPE,
+  BLOCKQUOTE_HOTKEY,
+  BLOCKQUOTE_COMPONENT,
+  BLOCKQUOTE_QUERY_CURRENT_BLOCK,
+  BLOCKQUOTE_QUERY_HAS,
+  BLOCKQUOTE_COMMAND_SOFT_BREAK,
+  BLOCKQUOTE_COMMAND_WRAP,
+  BLOCKQUOTE_COMMAND_UNWRAP,
+  BLOCKQUOTE_COMMAND_TOGGLE
+} from './blockquote.constants';
+export { BlockquoteQueryCurrentBlock, BlockquoteQueryHas, BlockquoteQueries } from './blockquote.queries';
+export {
+  BlockquoteCommandsConfig,
+  BlockquoteCommandSoftBreak,
+  BlockquoteCommandWrap,
+  BlockquoteCommandUnwrap,
+  BlockquoteCommandToggle,
+  BlockquoteCommands
+} from './blockquote.commands';
+export { BlockquotePluginConfig, BlockquotePlugin } from './blockquote.plugin';
+export { useBlockquoteIsActive, useBlockquoteOnClick } from './blockquote.hooks';

--- a/packages/slate-plugin-blockquote/tsconfig.json
+++ b/packages/slate-plugin-blockquote/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "./esm",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [
+    { "path": "../slate-core" },
+    { "path": "../slate-renderer" }
+  ],
+  "include": [
+		"./src"
+  ],
+  "exclude": [
+    "node_modules",
+    "./esm",
+    "./lib",
+    "./**/*.test.*"
+  ]
+}

--- a/stories/rich-editor/plugins.tsx
+++ b/stories/rich-editor/plugins.tsx
@@ -12,6 +12,7 @@ import {
 import { UnderlinePlugin, useUnderlineIsActive, useUnderlineOnClick } from '@artibox/slate-plugin-underline';
 import { HeadingPlugin, useHeadingIsActive, useHeadingOnClick } from '@artibox/slate-plugin-heading';
 import { SeparationLinePlugin, useSeparationLineOnClick } from '@artibox/slate-plugin-separation-line';
+import { BlockquotePlugin, useBlockquoteIsActive, useBlockquoteOnClick } from '@artibox/slate-plugin-blockquote';
 
 interface EditorPassable {
   editor: Editor;
@@ -60,6 +61,7 @@ const SeparationLineButton = ({ editor }: EditorPassable) => {
   const onClick = useSeparationLineOnClick(editor);
   return <button onClick={onClick}>separation line</button>;
 };
+const BlockquoteButton = createToggleButton(useBlockquoteIsActive, useBlockquoteOnClick, 'blockquote');
 
 export const plugins: Plugin[] = [
   BoldPlugin(),
@@ -70,6 +72,7 @@ export const plugins: Plugin[] = [
     disabled: [4, 5, 6]
   }),
   SeparationLinePlugin(),
+  BlockquotePlugin(),
   {
     renderEditor: (_, editor, next) => {
       return (
@@ -82,6 +85,7 @@ export const plugins: Plugin[] = [
           <Heading2Button editor={editor} />
           <Heading3Button editor={editor} />
           <SeparationLineButton editor={editor} />
+          <BlockquoteButton editor={editor} />
           {next()}
         </>
       );

--- a/stories/rich-editor/rich-editor.scss
+++ b/stories/rich-editor/rich-editor.scss
@@ -4,4 +4,10 @@
   width: 100%;
   height: 800px;
   box-sizing: border-box;
+
+  blockquote {
+    padding-left: 10px;
+    margin-left: 0px;
+    border-left: 3px solid #e5e5e5;
+  }
 }


### PR DESCRIPTION
As title.

The blockquote couldn't be nested.

Support key handlers:
- soft break on `mod+enter`
- press `enter` to end the blockquote if the current line is empty.
- press `backspace` to end the blockquote if the selection is not expanded and empty.