### PR TITLE
fix: rename onMouseDown to onClick of ToolHook

### DIFF
--- a/packages/slate-blockquote/src/blockquote.ts
+++ b/packages/slate-blockquote/src/blockquote.ts
@@ -47,7 +47,7 @@ export function createBlockquote(config?: CreatBlockquoteeConfig): Blockquote {
       const { command = 'toggle', activeNotProvided = false } = config || {};
       return editor => ({
         active: !activeNotProvided && controller.isSelectionIn(editor),
-        onMouseDown: useCallback(() => controller[command](editor), [editor])
+        onClick: useCallback(() => controller[command](editor), [editor])
       });
     }
   };

--- a/packages/slate-common/src/typings/tool.ts
+++ b/packages/slate-common/src/typings/tool.ts
@@ -12,7 +12,7 @@ export type ToolHook = (
   setInputConfig: SetInputConfig
 ) => {
   active?: boolean;
-  onMouseDown: MouseEventHandler;
+  onClick: MouseEventHandler;
 };
 
 /**

--- a/packages/slate-facebook/src/facebook.ts
+++ b/packages/slate-facebook/src/facebook.ts
@@ -44,7 +44,7 @@ export function createFacebook(config?: CreateFacebookConfig): Facebook {
       };
 
       return (editor, defaultSetInputConfig) => ({
-        onMouseDown: useCallback(() => {
+        onClick: useCallback(() => {
           if (setInputConfig) {
             setInputConfig(editor, inputConfig);
           } else {

--- a/packages/slate-heading/src/heading.ts
+++ b/packages/slate-heading/src/heading.ts
@@ -51,7 +51,7 @@ export function createHeading(config?: CreateHeadingonfig): Heading {
       const { level } = config;
       return editor => ({
         active: controller.isSelectionIn(editor, level),
-        onMouseDown: useCallback(() => controller.toggle(editor, level), [editor])
+        onClick: useCallback(() => controller.toggle(editor, level), [editor])
       });
     }
   };

--- a/packages/slate-instagram/src/instagram.ts
+++ b/packages/slate-instagram/src/instagram.ts
@@ -44,7 +44,7 @@ export function createInstagram(config?: CreateInstagramConfig): Instagram {
       };
 
       return (editor, defaultSetInputConfig) => ({
-        onMouseDown: useCallback(() => {
+        onClick: useCallback(() => {
           if (setInputConfig) {
             setInputConfig(editor, inputConfig);
           } else {

--- a/packages/slate-link/src/link.ts
+++ b/packages/slate-link/src/link.ts
@@ -41,7 +41,7 @@ export function createLink(config?: CreateLinkConfig): Link {
 
       return (editor, setInputConfig) => ({
         active: activeProvided && controller.isSelectionIn(editor),
-        onMouseDown: useCallback(() => {
+        onClick: useCallback(() => {
           if (command === 'set') {
             setInputConfig(inputConfig);
           } else if (command === 'remove') {

--- a/packages/slate-list/src/list.ts
+++ b/packages/slate-list/src/list.ts
@@ -41,7 +41,7 @@ export function createList(config?: CreateListConfig): List {
     forToolHook(config: ListForToolHookConfig): ToolHook {
       const { orderedType, command = 'toggle' } = config;
       return editor => ({
-        onMouseDown: useCallback(() => controller[command](editor, orderedType), [editor])
+        onClick: useCallback(() => controller[command](editor, orderedType), [editor])
       });
     }
   };

--- a/packages/slate-separation-line/src/separation-line.ts
+++ b/packages/slate-separation-line/src/separation-line.ts
@@ -28,7 +28,7 @@ export function createSeparationLine(config?: CreateSeparationLineConfig): Separ
       };
     },
     forToolHook: () => editor => ({
-      onMouseDown: useCallback(() => controller.add(editor), [editor])
+      onClick: useCallback(() => controller.add(editor), [editor])
     })
   };
 }

--- a/packages/slate-toggle-mark/src/toggle-mark.ts
+++ b/packages/slate-toggle-mark/src/toggle-mark.ts
@@ -37,7 +37,7 @@ export function createToggleMarkCreator(defaults: ToggleMarkDefaultConfig) {
         /**
          * Toggle the mark while tool clicked.
          */
-        onMouseDown: useCallback(() => controller.toggle(editor), [editor])
+        onClick: useCallback(() => controller.toggle(editor), [editor])
       })
     };
   }

--- a/packages/slate-toolbar/src/components/toolbar-icon.tsx
+++ b/packages/slate-toolbar/src/components/toolbar-icon.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, MouseEventHandler } from 'react';
 import cx from 'classnames';
 import { IconDefinition } from '@artibox/icons';
 import Icon from '@artibox/components/Icon';
@@ -11,19 +11,19 @@ interface ToolbarIconInnerProps extends ReturnType<ToolHook> {
   icon: IconDefinition;
 }
 
+const preventDefault: MouseEventHandler = event => event.preventDefault();
+
 const ToolbarIconInner = memo<ToolbarIconInnerProps>(
-  ({ active, onMouseDown, icon }) => (
+  ({ active, onClick, icon }) => (
     <span
       className={cx(`${clsPrefix}__icon`, { [`${clsPrefix}__icon--active`]: active })}
-      onMouseDown={event => {
-        event.preventDefault();
-        onMouseDown(event);
-      }}
+      onClick={onClick}
+      onMouseDown={preventDefault}
     >
       <Icon icon={icon} />
     </span>
   ),
-  (prev, next) => prev.active === next.active && prev.onMouseDown === next.onMouseDown && prev.icon === next.icon
+  (prev, next) => prev.active === next.active && prev.onClick === next.onClick && prev.icon === next.icon
 );
 
 export interface ToolbarIconProps extends WithEditor, Exclude<Tool, TOOLBAR_DIVIDER> {
@@ -31,8 +31,8 @@ export interface ToolbarIconProps extends WithEditor, Exclude<Tool, TOOLBAR_DIVI
 }
 
 function ToolbarIcon({ icon, hook, editor, setToolInput }: ToolbarIconProps) {
-  const { active, onMouseDown } = hook(editor, setToolInput);
-  return <ToolbarIconInner active={active} onMouseDown={onMouseDown} icon={icon} />;
+  const { active, onClick } = hook(editor, setToolInput);
+  return <ToolbarIconInner active={active} onClick={onClick} icon={icon} />;
 }
 
 export default ToolbarIcon;

--- a/packages/slate-video/src/video.ts
+++ b/packages/slate-video/src/video.ts
@@ -41,7 +41,7 @@ export function createVideo(config?: CreateVideoConfig): Video {
       };
 
       return (editor, defaultSetInputConfig) => ({
-        onMouseDown: useCallback(() => {
+        onClick: useCallback(() => {
           if (setInputConfig) {
             setInputConfig(editor, inputConfig);
           } else {


### PR DESCRIPTION
The event need to prevent default is onMouseDown, not onClick.
So rename back to onClick